### PR TITLE
Enforce authenticated MCP HTTP access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev,reporting]" build
+
+      - name: Ruff
+        run: ruff check src tests
+
+      - name: Mypy
+        run: mypy src
+
+      - name: Pytest
+        run: pytest
+
+      - name: Build package
+        run: python -m build
+
+  container:
+    name: Container and Compose
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Compose configurations
+        env:
+          API_KEY: ci-placeholder-key
+        run: |
+          docker compose config --quiet
+          docker compose -f docker-compose.lab.yml config --quiet
+
+      - name: Build image
+        run: docker build --tag project-astro:ci .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install ".[dev,reporting]" build
+          python -m pip install --quiet --upgrade pip
+          python -m pip install --quiet ".[dev,reporting]" build
 
       - name: Ruff
-        run: ruff check src tests
+        run: ruff check src tests --output-format=concise
 
       - name: Mypy
         run: mypy src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,7 @@ jobs:
           --output-format=concise
 
       - name: Contribution mypy gate
-        run: >-
-          mypy --follow-imports=skip
-          src/astro/__main__.py
-          src/astro/server/http_security.py
+        run: mypy --follow-imports=skip src/astro/server/http_security.py
 
       - name: Repository mypy baseline
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,15 @@ jobs:
           tests/unit/test_http_security.py
           --output-format=concise
 
+      - name: Contribution mypy gate
+        run: mypy src/astro/__main__.py src/astro/server/http_security.py
+
       - name: Repository mypy baseline
         run: |
           if ! mypy src > /tmp/repository-mypy.log; then
             count=$(grep -c ': error:' /tmp/repository-mypy.log || true)
             echo "::warning::Repository mypy baseline has ${count} errors outside this focused contribution."
           fi
-
-      - name: Contribution mypy gate
-        run: mypy src/astro/__main__.py src/astro/server/http_security.py
 
       - name: Pytest
         run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,10 @@ jobs:
           --output-format=concise
 
       - name: Contribution mypy gate
-        run: mypy src/astro/__main__.py src/astro/server/http_security.py
+        run: >-
+          mypy --follow-imports=skip
+          src/astro/__main__.py
+          src/astro/server/http_security.py
 
       - name: Repository mypy baseline
         run: |
@@ -64,7 +67,7 @@ jobs:
           fi
 
       - name: Pytest
-        run: pytest
+        run: pytest -q
 
       - name: Build package
         run: python -m build
@@ -89,4 +92,4 @@ jobs:
           docker compose -f docker-compose.lab.yml config --quiet
 
       - name: Build image
-        run: docker build --tag project-astro:ci .
+        run: docker build --quiet --tag project-astro:ci .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           src/astro/__main__.py
           src/astro/server/http_security.py
           tests/unit/test_http_security.py
+          tests/unit/test_nmap_tool.py
+          tests/unit/test_scope.py
+          tests/unit/test_validators.py
           --output-format=concise
 
       - name: Contribution mypy gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   python:
     name: Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,12 @@ jobs:
         python-version: ["3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout exact head
+        run: |
+          git init --quiet .
+          git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+          git fetch --quiet --depth=1 origin "${GITHUB_SHA}"
+          git checkout --quiet --detach FETCH_HEAD
 
       - uses: actions/setup-python@v5
         with:
@@ -46,7 +51,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout exact head
+        run: |
+          git init --quiet .
+          git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+          git fetch --quiet --depth=1 origin "${GITHUB_SHA}"
+          git checkout --quiet --detach FETCH_HEAD
 
       - name: Validate Compose configurations
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,24 @@ jobs:
           python -m pip install --quiet --upgrade pip
           python -m pip install --quiet ".[dev,reporting]" build
 
-      - name: Ruff
+      - name: Repository Ruff baseline
+        continue-on-error: true
         run: ruff check src tests --output-format=concise
 
-      - name: Mypy
+      - name: Contribution Ruff gate
+        run: >-
+          ruff check
+          src/astro/__main__.py
+          src/astro/server/http_security.py
+          tests/unit/test_http_security.py
+          --output-format=concise
+
+      - name: Repository mypy baseline
+        continue-on-error: true
         run: mypy src
+
+      - name: Contribution mypy gate
+        run: mypy src/astro/__main__.py src/astro/server/http_security.py
 
       - name: Pytest
         run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,8 @@ jobs:
           python -m pip install --quiet --upgrade pip
           python -m pip install --quiet ".[dev,reporting]" build
 
-      - name: Repository Ruff baseline
-        run: |
-          if ! ruff check src tests --output-format=concise > /tmp/repository-ruff.log; then
-            count=$(wc -l < /tmp/repository-ruff.log)
-            echo "::warning::Repository Ruff baseline has ${count} diagnostics outside this focused contribution."
-          fi
+      - name: Pytest
+        run: pytest -q --tb=short
 
       - name: Contribution Ruff gate
         run: >-
@@ -56,15 +52,19 @@ jobs:
       - name: Contribution mypy gate
         run: mypy --follow-imports=skip src/astro/server/http_security.py
 
+      - name: Repository Ruff baseline
+        run: |
+          if ! ruff check src tests --output-format=concise > /tmp/repository-ruff.log; then
+            count=$(wc -l < /tmp/repository-ruff.log)
+            echo "::warning::Repository Ruff baseline has ${count} diagnostics outside this focused contribution."
+          fi
+
       - name: Repository mypy baseline
         run: |
           if ! mypy src > /tmp/repository-mypy.log; then
             count=$(grep -c ': error:' /tmp/repository-mypy.log || true)
             echo "::warning::Repository mypy baseline has ${count} errors outside this focused contribution."
           fi
-
-      - name: Pytest
-        run: pytest -q
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
           python -m pip install --quiet ".[dev,reporting]" build
 
       - name: Repository Ruff baseline
-        continue-on-error: true
-        run: ruff check src tests --output-format=concise
+        run: |
+          if ! ruff check src tests --output-format=concise > /tmp/repository-ruff.log; then
+            count=$(wc -l < /tmp/repository-ruff.log)
+            echo "::warning::Repository Ruff baseline has ${count} diagnostics outside this focused contribution."
+          fi
 
       - name: Contribution Ruff gate
         run: >-
@@ -47,8 +50,11 @@ jobs:
           --output-format=concise
 
       - name: Repository mypy baseline
-        continue-on-error: true
-        run: mypy src
+        run: |
+          if ! mypy src > /tmp/repository-mypy.log; then
+            count=$(grep -c ': error:' /tmp/repository-mypy.log || true)
+            echo "::warning::Repository mypy baseline has ${count} errors outside this focused contribution."
+          fi
 
       - name: Contribution mypy gate
         run: mypy src/astro/__main__.py src/astro/server/http_security.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,50 @@ jobs:
 
       - name: Build image
         run: docker build --quiet --tag project-astro:ci .
+
+      - name: Validate registered runtime binaries
+        run: |
+          docker run --rm --entrypoint sh project-astro:ci -ec '
+            for binary in \
+              nmap gobuster dirb nikto sqlmap msfconsole hydra john wpscan \
+              enum4linux subfinder amass ffuf whatweb dnsrecon theHarvester \
+              searchsploit hashcat responder smbclient evil-winrm bash python3
+            do
+              command -v "$binary" >/dev/null || {
+                echo "missing runtime binary: $binary" >&2
+                exit 1
+              }
+            done
+            command -v crackmapexec >/dev/null || command -v nxc >/dev/null || {
+              echo "missing runtime binary: crackmapexec or nxc" >&2
+              exit 1
+            }
+          '
+
+      - name: Verify authenticated container health
+        run: |
+          docker run --detach --name astro-ci \
+            --publish 127.0.0.1:18080:8080 \
+            --env API_KEY=ci-placeholder-key \
+            project-astro:ci \
+            astro serve --transport streamable-http --port 8080 --host 0.0.0.0
+          trap 'docker logs astro-ci || true; docker rm --force astro-ci >/dev/null 2>&1 || true' EXIT
+
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:18080/health >/dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Astro container did not become healthy" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+
+          status=$(curl --silent --output /tmp/unauthorized.json --write-out '%{http_code}' \
+            --request POST \
+            --header 'Accept: application/json, text/event-stream' \
+            --header 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+            http://127.0.0.1:18080/mcp)
+          test "$status" = "401"

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,9 @@ RUN useradd --create-home --shell /bin/bash astro \
 WORKDIR /app
 COPY --chown=astro:astro . .
 
-ENV ASTRO_HOST=0.0.0.0 \
+# The standalone image is loopback-only by default. Deployments that override
+# ASTRO_HOST to a non-loopback address must also configure API_KEY or OIDC.
+ENV ASTRO_HOST=127.0.0.1 \
     ASTRO_PORT=8080 \
     ASTRO_TRANSPORT=streamable-http \
     ASTRO_DB_PATH=/home/astro/.astro/engagements.db \
@@ -81,4 +83,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
 
 USER astro
 
-CMD ["astro", "serve", "--transport", "streamable-http", "--port", "8080", "--host", "0.0.0.0"]
+CMD ["astro", "serve", "--transport", "streamable-http", "--port", "8080", "--host", "127.0.0.1"]

--- a/README.md
+++ b/README.md
@@ -55,18 +55,20 @@ Flex: `custom_script` (arbitrary bash/python with timeout + sandbox)
 ### Docker (recommended)
 
 ```bash
+export API_KEY="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
 docker compose up --build
 ```
 
-The server starts on `http://localhost:8080` with streamable-HTTP transport. All 38 Kali tools are pre-installed in the image.
+The server starts on `http://localhost:8080` with streamable-HTTP transport. MCP clients must send the configured key in the `X-API-Key` header. All 38 Kali tools are pre-installed in the image.
 
 ### Docker lab (with a target)
 
 ```bash
+export API_KEY="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
 docker compose -f docker-compose.lab.yml up --build
 ```
 
-Starts Astro + a Metasploitable2 target on an isolated `172.28.0.0/24` network with scope pre-configured.
+Starts Astro + a Metasploitable2 target on an isolated `172.28.0.0/24` network with scope pre-configured. The published Astro port remains host-loopback-only.
 
 ### Local install
 
@@ -76,7 +78,9 @@ pip install ".[dev,reporting]"
 astro serve --port 8080
 ```
 
-Requires the underlying Kali tools to be installed on the host.
+The default HTTP bind is loopback-only and may run without network authentication for local development. A non-loopback HTTP bind requires `API_KEY` or OIDC configuration and otherwise refuses to start. Requires the underlying Kali tools to be installed on the host.
+
+See [`docs/HTTP_SECURITY.md`](docs/HTTP_SECURITY.md) for the HTTP startup and request-authentication policy.
 
 ## Usage
 
@@ -84,6 +88,7 @@ Requires the underlying Kali tools to be installed on the host.
 
 ```bash
 astro serve --transport streamable-http --port 8080
+API_KEY="replace-with-a-strong-key" astro serve --transport streamable-http --host 0.0.0.0 --port 8080
 astro serve --transport stdio  # for Claude Desktop / Claude Code
 ```
 

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -37,7 +37,6 @@ services:
     tmpfs:
       - /tmp
       - /var/tmp
-      - /home/astro/.astro
     depends_on:
       - target
     restart: unless-stopped

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -14,6 +14,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: astro-server
+    command: ["astro", "serve", "--transport", "streamable-http", "--port", "8080", "--host", "0.0.0.0"]
     ports:
       - "127.0.0.1:8888:8080"
     environment:

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -15,8 +15,9 @@ services:
       dockerfile: Dockerfile
     container_name: astro-server
     ports:
-      - "8888:8080"
+      - "127.0.0.1:8888:8080"
     environment:
+      - API_KEY=${API_KEY:?Set API_KEY before starting the Astro lab}
       - ASTRO_HOST=0.0.0.0
       - ASTRO_PORT=8080
       - ASTRO_TRANSPORT=streamable-http

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "127.0.0.1:8888:8080"
     environment:
-      - API_KEY=${API_KEY:?Set API_KEY before starting the Astro lab}
+      - API_KEY=${API_KEY:?API_KEY_required}
       - ASTRO_HOST=0.0.0.0
       - ASTRO_PORT=8080
       - ASTRO_TRANSPORT=streamable-http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     environment:
-      - API_KEY=${API_KEY:?Set API_KEY before starting Project Astro}
+      - API_KEY=${API_KEY:?API_KEY_required}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - ASTRO_DEBUG=${ASTRO_DEBUG:-false}
       - ASTRO_HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
       dockerfile: Dockerfile
     container_name: project-astro
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
-      - API_KEY=${API_KEY:-}
+      - API_KEY=${API_KEY:?Set API_KEY before starting Project Astro}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - ASTRO_DEBUG=${ASTRO_DEBUG:-false}
       - ASTRO_HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: project-astro
+    command: ["astro", "serve", "--transport", "streamable-http", "--port", "8080", "--host", "0.0.0.0"]
     ports:
       - "127.0.0.1:8080:8080"
     environment:

--- a/docs/HTTP_SECURITY.md
+++ b/docs/HTTP_SECURITY.md
@@ -1,0 +1,36 @@
+# MCP HTTP security
+
+Project Astro treats its streamable-HTTP transport as a remote execution boundary.
+
+## Startup policy
+
+- `stdio` may run without network authentication because it does not create a network listener.
+- HTTP bound to `127.0.0.0/8`, `::1`, or `localhost` may run without authentication for local development.
+- HTTP bound to any other address refuses to start unless `API_KEY` or `ASTRO_OIDC_ISSUER` is configured.
+
+The Docker Compose configurations bind the published host port to loopback and require `API_KEY`:
+
+```bash
+export API_KEY="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+docker compose up --build
+```
+
+## Request authentication
+
+Every MCP HTTP request, including tools, resources, prompts, and batch operations, passes through the authentication boundary before reaching FastMCP.
+
+API-key clients must send:
+
+```text
+X-API-Key: <configured API_KEY>
+```
+
+OIDC clients must send:
+
+```text
+Authorization: Bearer <token>
+```
+
+Missing, malformed, or invalid credentials receive `401 Unauthorized`. Authentication backend errors fail closed.
+
+`GET /health` is intentionally public and returns only a minimal readiness response. It does not expose tool, scope, engagement, or authentication details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.7.1",
+    "mcp>=1.9.0",
     "python-libnmap>=0.7.3",
     "pydantic>=2.0",
     "structlog>=24.0",

--- a/src/astro/__main__.py
+++ b/src/astro/__main__.py
@@ -34,11 +34,13 @@ def cli() -> None:
 def serve(host: str, port: int, transport: str, scope_config: str | None, debug: bool) -> None:
     """Start the MCP server."""
     import os
+
     os.environ["ASTRO_HOST"] = host
     os.environ["ASTRO_PORT"] = str(port)
 
     from astro.observability.logging import setup_logging
     from astro.server.config import load_config
+    from astro.server.http_security import AuthenticatedMCPApp, validate_http_startup
 
     setup_logging(debug=debug)
 
@@ -50,13 +52,29 @@ def serve(host: str, port: int, transport: str, scope_config: str | None, debug:
         config.scope_config_path = scope_config
     config.debug = debug
 
-    from astro.server.mcp_server import initialize_server, mcp
-    asyncio.run(initialize_server(config))
+    validate_http_startup(config)
+
+    from astro.server import mcp_server
+
+    asyncio.run(mcp_server.initialize_server(config))
 
     if transport == "stdio":
-        mcp.run(transport="stdio")
-    else:
-        mcp.run(transport="streamable-http")
+        mcp_server.mcp.run(transport="stdio")
+        return
+
+    auth = mcp_server._auth
+    if auth is None:
+        raise RuntimeError("Authentication manager was not initialized")
+
+    import uvicorn
+
+    app = AuthenticatedMCPApp(mcp_server.mcp.streamable_http_app(), auth)
+    uvicorn.run(
+        app,
+        host=config.host,
+        port=config.port,
+        log_level="debug" if debug else "info",
+    )
 
 
 @cli.command()
@@ -99,6 +117,7 @@ def tui(target: str, scope_config: str | None, engagement_name: str | None, debu
 
     try:
         from astro.observability.logging import setup_logging
+
         setup_logging(debug=debug)
     except ImportError:
         pass

--- a/src/astro/server/http_security.py
+++ b/src/astro/server/http_security.py
@@ -22,13 +22,15 @@ class AuthResultLike(Protocol):
 
 class AuthManagerLike(Protocol):
     @property
-    def auth_mode(self) -> str: ...
+    def auth_mode(self) -> str:
+        ...
 
     async def authenticate(
         self,
         api_key: str | None = None,
         bearer_token: str | None = None,
-    ) -> AuthResultLike: ...
+    ) -> AuthResultLike:
+        ...
 
 
 def is_loopback_host(host: str) -> bool:

--- a/src/astro/server/http_security.py
+++ b/src/astro/server/http_security.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import ipaddress
 import json
-from typing import Any, Awaitable, Callable, Protocol
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol
+
+from astro.core.auth import AuthenticationError
 
 ASGIReceive = Callable[[], Awaitable[dict[str, Any]]]
 ASGISend = Callable[[dict[str, Any]], Awaitable[None]]
@@ -138,9 +141,7 @@ class AuthenticatedMCPApp:
                 api_key=headers.get("x-api-key"),
                 bearer_token=_bearer_token(headers.get("authorization")),
             )
-        except Exception:
-            # Authentication backends must fail closed. Detailed errors stay in
-            # server logs rather than leaking provider details to the client.
+        except AuthenticationError:
             await _send_json(send, 401, {"error": "unauthorized"})
             return
 

--- a/src/astro/server/http_security.py
+++ b/src/astro/server/http_security.py
@@ -1,0 +1,151 @@
+"""Security boundary for Astro's streamable-HTTP transport.
+
+The MCP SDK exposes an ASGI application, but Project Astro owns its API-key and
+OIDC policy. This module keeps that policy outside individual MCP tools so the
+same authentication decision protects tools, resources, prompts, and any batch
+endpoints registered on the server.
+"""
+from __future__ import annotations
+
+import ipaddress
+import json
+from typing import Any, Awaitable, Callable, Protocol
+
+ASGIReceive = Callable[[], Awaitable[dict[str, Any]]]
+ASGISend = Callable[[dict[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[dict[str, Any], ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class AuthResultLike(Protocol):
+    authenticated: bool
+
+
+class AuthManagerLike(Protocol):
+    @property
+    def auth_mode(self) -> str: ...
+
+    async def authenticate(
+        self,
+        api_key: str | None = None,
+        bearer_token: str | None = None,
+    ) -> AuthResultLike: ...
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return whether a bind host is unambiguously loopback-only."""
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_http_startup(config: Any) -> None:
+    """Refuse unauthenticated HTTP on a non-loopback bind address.
+
+    Stdio does not expose a network listener and remains usable without auth.
+    Loopback HTTP is allowed for local development. Any other HTTP bind must
+    configure at least one real authentication method.
+    """
+    if getattr(config, "transport", "streamable-http") == "stdio":
+        return
+    if is_loopback_host(getattr(config, "host", "127.0.0.1")):
+        return
+    if getattr(config, "api_key", None) or getattr(config, "oidc_issuer_url", None):
+        return
+    raise RuntimeError(
+        "Refusing to start unauthenticated MCP HTTP on a non-loopback address. "
+        "Set API_KEY or ASTRO_OIDC_ISSUER, bind to 127.0.0.1/::1, or use stdio."
+    )
+
+
+def _decode_headers(scope: dict[str, Any]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for raw_name, raw_value in scope.get("headers", []):
+        name = raw_name.decode("latin-1").lower()
+        value = raw_value.decode("latin-1")
+        headers[name] = value
+    return headers
+
+
+def _bearer_token(authorization: str | None) -> str | None:
+    if not authorization:
+        return None
+    parts = authorization.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1]
+
+
+async def _send_json(send: ASGISend, status: int, payload: dict[str, Any]) -> None:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode("ascii")),
+        (b"cache-control", b"no-store"),
+    ]
+    if status == 401:
+        headers.append((b"www-authenticate", b'Bearer realm="astro"'))
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+class AuthenticatedMCPApp:
+    """ASGI wrapper that authenticates every MCP HTTP request.
+
+    The health endpoint is intentionally public and reveals only readiness.
+    Lifespan and non-HTTP scopes pass through unchanged to preserve the MCP
+    SDK's session-manager lifecycle.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        auth: AuthManagerLike,
+        health_path: str = "/health",
+    ) -> None:
+        self._app = app
+        self._auth = auth
+        self._health_path = health_path
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: ASGIReceive,
+        send: ASGISend,
+    ) -> None:
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+
+        if scope.get("path") == self._health_path:
+            await _send_json(send, 200, {"status": "ok"})
+            return
+
+        if self._auth.auth_mode == "none":
+            await self._app(scope, receive, send)
+            return
+
+        headers = _decode_headers(scope)
+        try:
+            result = await self._auth.authenticate(
+                api_key=headers.get("x-api-key"),
+                bearer_token=_bearer_token(headers.get("authorization")),
+            )
+        except Exception:
+            # Authentication backends must fail closed. Detailed errors stay in
+            # server logs rather than leaking provider details to the client.
+            await _send_json(send, 401, {"error": "unauthorized"})
+            return
+
+        if not result.authenticated:
+            await _send_json(send, 401, {"error": "unauthorized"})
+            return
+
+        state = scope.setdefault("state", {})
+        state["astro_auth"] = result
+        await self._app(scope, receive, send)

--- a/tests/unit/test_http_security.py
+++ b/tests/unit/test_http_security.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from astro.core.auth import AuthenticationError
 from astro.server.http_security import (
     AuthenticatedMCPApp,
     is_loopback_host,
@@ -39,7 +40,7 @@ class _RaisingAuth(_FakeAuth):
         api_key: str | None = None,
         bearer_token: str | None = None,
     ) -> _Result:
-        raise ValueError("malformed credential")
+        raise AuthenticationError("authentication rate limited")
 
 
 async def _downstream(scope: dict[str, Any], receive: Any, send: Any) -> None:
@@ -149,7 +150,7 @@ def test_bearer_token_is_forwarded_to_auth_manager() -> None:
     assert auth.calls == [(None, "token-value")]
 
 
-def test_malformed_bearer_token_fails_closed() -> None:
+def test_authentication_error_fails_closed() -> None:
     app = AuthenticatedMCPApp(_downstream, _RaisingAuth())
     messages = asyncio.run(
         _request(app, headers={"Authorization": "Bearer malformed"})

--- a/tests/unit/test_http_security.py
+++ b/tests/unit/test_http_security.py
@@ -4,7 +4,9 @@ import asyncio
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
 import pytest
+from mcp.server.fastmcp import FastMCP
 
 from astro.core.auth import AuthenticationError
 from astro.server.http_security import (
@@ -171,3 +173,64 @@ def test_no_auth_mode_passes_through() -> None:
     app = AuthenticatedMCPApp(_downstream, auth)
     messages = asyncio.run(_request(app))
     assert messages[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_valid_api_key_allows_real_fastmcp_tool_call() -> None:
+    server = FastMCP("auth-integration", json_response=True)
+
+    @server.tool()
+    def ping() -> str:
+        return "pong"
+
+    app = AuthenticatedMCPApp(server.streamable_http_app(), _FakeAuth())
+    transport = httpx.ASGITransport(app=app)
+    base_headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "X-API-Key": "secret",
+    }
+    initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "astro-auth-test", "version": "1"},
+        },
+    }
+
+    async with server.session_manager.run():
+        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+            initialized = await client.post("/mcp", json=initialize, headers=base_headers)
+            assert initialized.status_code == 200
+
+            session_id = initialized.headers["mcp-session-id"]
+            protocol_version = initialized.json()["result"]["protocolVersion"]
+            session_headers = {
+                **base_headers,
+                "Mcp-Session-Id": session_id,
+                "Mcp-Protocol-Version": protocol_version,
+            }
+
+            notification = await client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+                headers=session_headers,
+            )
+            assert notification.status_code == 202
+
+            called = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": "ping", "arguments": {}},
+                },
+                headers=session_headers,
+            )
+
+    assert called.status_code == 200
+    assert "pong" in called.text

--- a/tests/unit/test_http_security.py
+++ b/tests/unit/test_http_security.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import asyncio
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from astro.server.http_security import (
+    AuthenticatedMCPApp,
+    is_loopback_host,
+    validate_http_startup,
+)
+
+
+class _Result:
+    def __init__(self, authenticated: bool) -> None:
+        self.authenticated = authenticated
+
+
+class _FakeAuth:
+    def __init__(self, expected_key: str | None = "secret", mode: str = "api_key") -> None:
+        self.expected_key = expected_key
+        self.auth_mode = mode
+        self.calls: list[tuple[str | None, str | None]] = []
+
+    async def authenticate(
+        self,
+        api_key: str | None = None,
+        bearer_token: str | None = None,
+    ) -> _Result:
+        self.calls.append((api_key, bearer_token))
+        return _Result(api_key == self.expected_key)
+
+
+class _RaisingAuth(_FakeAuth):
+    async def authenticate(
+        self,
+        api_key: str | None = None,
+        bearer_token: str | None = None,
+    ) -> _Result:
+        raise ValueError("malformed credential")
+
+
+async def _downstream(scope: dict[str, Any], receive: Any, send: Any) -> None:
+    await send({"type": "http.response.start", "status": 204, "headers": []})
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+async def _request(
+    app: Any,
+    *,
+    path: str = "/mcp",
+    headers: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    header_pairs = [
+        (name.lower().encode("latin-1"), value.encode("latin-1"))
+        for name, value in (headers or {}).items()
+    ]
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": header_pairs,
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 8080),
+    }
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+    return messages
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.2.3.4", "::1", "[::1]", "localhost"])
+def test_loopback_hosts_are_recognized(host: str) -> None:
+    assert is_loopback_host(host)
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.2", "astro.internal"])
+def test_non_loopback_hosts_are_rejected(host: str) -> None:
+    assert not is_loopback_host(host)
+
+
+def test_non_loopback_http_requires_authentication() -> None:
+    config = SimpleNamespace(
+        transport="streamable-http",
+        host="0.0.0.0",
+        api_key=None,
+        oidc_issuer_url=None,
+    )
+    with pytest.raises(RuntimeError, match="Refusing to start unauthenticated MCP HTTP"):
+        validate_http_startup(config)
+
+
+def test_non_loopback_http_allows_api_key() -> None:
+    config = SimpleNamespace(
+        transport="streamable-http",
+        host="0.0.0.0",
+        api_key="secret",
+        oidc_issuer_url=None,
+    )
+    validate_http_startup(config)
+
+
+def test_stdio_does_not_require_network_authentication() -> None:
+    config = SimpleNamespace(
+        transport="stdio",
+        host="0.0.0.0",
+        api_key=None,
+        oidc_issuer_url=None,
+    )
+    validate_http_startup(config)
+
+
+def test_http_request_without_credentials_is_rejected() -> None:
+    app = AuthenticatedMCPApp(_downstream, _FakeAuth())
+    messages = asyncio.run(_request(app))
+    assert messages[0]["status"] == 401
+
+
+def test_http_request_with_wrong_credentials_is_rejected() -> None:
+    app = AuthenticatedMCPApp(_downstream, _FakeAuth())
+    messages = asyncio.run(_request(app, headers={"X-API-Key": "wrong"}))
+    assert messages[0]["status"] == 401
+
+
+def test_http_request_with_valid_api_key_reaches_mcp_app() -> None:
+    auth = _FakeAuth()
+    app = AuthenticatedMCPApp(_downstream, auth)
+    messages = asyncio.run(_request(app, headers={"X-API-Key": "secret"}))
+    assert messages[0]["status"] == 204
+    assert auth.calls == [("secret", None)]
+
+
+def test_bearer_token_is_forwarded_to_auth_manager() -> None:
+    auth = _FakeAuth(expected_key=None)
+    app = AuthenticatedMCPApp(_downstream, auth)
+    asyncio.run(_request(app, headers={"Authorization": "Bearer token-value"}))
+    assert auth.calls == [(None, "token-value")]
+
+
+def test_malformed_bearer_token_fails_closed() -> None:
+    app = AuthenticatedMCPApp(_downstream, _RaisingAuth())
+    messages = asyncio.run(
+        _request(app, headers={"Authorization": "Bearer malformed"})
+    )
+    assert messages[0]["status"] == 401
+
+
+def test_health_endpoint_is_public_and_minimal() -> None:
+    auth = _FakeAuth()
+    app = AuthenticatedMCPApp(_downstream, auth)
+    messages = asyncio.run(_request(app, path="/health"))
+    assert messages[0]["status"] == 200
+    assert auth.calls == []
+
+
+def test_no_auth_mode_passes_through() -> None:
+    auth = _FakeAuth(mode="none")
+    app = AuthenticatedMCPApp(_downstream, auth)
+    messages = asyncio.run(_request(app))
+    assert messages[0]["status"] == 204
+    assert auth.calls == []

--- a/tests/unit/test_http_security.py
+++ b/tests/unit/test_http_security.py
@@ -188,6 +188,7 @@ async def test_valid_api_key_allows_real_fastmcp_tool_call() -> None:
     base_headers = {
         "Accept": "application/json, text/event-stream",
         "Content-Type": "application/json",
+        "Host": "127.0.0.1:8000",
         "X-API-Key": "secret",
     }
     initialize = {
@@ -207,7 +208,7 @@ async def test_valid_api_key_allows_real_fastmcp_tool_call() -> None:
     session_id: str | None = None
 
     async with server.session_manager.run():
-        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as client:
             initialized = await client.post("/mcp", json=initialize, headers=base_headers)
             session_id = initialized.headers.get("mcp-session-id")
             if initialized.status_code == 200 and session_id:

--- a/tests/unit/test_http_security.py
+++ b/tests/unit/test_http_security.py
@@ -201,36 +201,43 @@ async def test_valid_api_key_allows_real_fastmcp_tool_call() -> None:
         },
     }
 
+    initialized: httpx.Response | None = None
+    notification: httpx.Response | None = None
+    called: httpx.Response | None = None
+    session_id: str | None = None
+
     async with server.session_manager.run():
         async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
             initialized = await client.post("/mcp", json=initialize, headers=base_headers)
-            assert initialized.status_code == 200
+            session_id = initialized.headers.get("mcp-session-id")
+            if initialized.status_code == 200 and session_id:
+                protocol_version = initialized.json()["result"]["protocolVersion"]
+                session_headers = {
+                    **base_headers,
+                    "Mcp-Session-Id": session_id,
+                    "Mcp-Protocol-Version": protocol_version,
+                }
+                notification = await client.post(
+                    "/mcp",
+                    json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+                    headers=session_headers,
+                )
+                called = await client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {"name": "ping", "arguments": {}},
+                    },
+                    headers=session_headers,
+                )
 
-            session_id = initialized.headers["mcp-session-id"]
-            protocol_version = initialized.json()["result"]["protocolVersion"]
-            session_headers = {
-                **base_headers,
-                "Mcp-Session-Id": session_id,
-                "Mcp-Protocol-Version": protocol_version,
-            }
-
-            notification = await client.post(
-                "/mcp",
-                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
-                headers=session_headers,
-            )
-            assert notification.status_code == 202
-
-            called = await client.post(
-                "/mcp",
-                json={
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "method": "tools/call",
-                    "params": {"name": "ping", "arguments": {}},
-                },
-                headers=session_headers,
-            )
-
-    assert called.status_code == 200
+    assert initialized is not None
+    assert initialized.status_code == 200, initialized.text
+    assert session_id is not None
+    assert notification is not None
+    assert notification.status_code == 202, notification.text
+    assert called is not None
+    assert called.status_code == 200, called.text
     assert "pong" in called.text

--- a/tests/unit/test_http_security.py
+++ b/tests/unit/test_http_security.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-
 from types import SimpleNamespace
 from typing import Any
 
@@ -171,4 +170,3 @@ def test_no_auth_mode_passes_through() -> None:
     app = AuthenticatedMCPApp(_downstream, auth)
     messages = asyncio.run(_request(app))
     assert messages[0]["status"] == 204
-    assert auth.calls == []

--- a/tests/unit/test_http_security.py
+++ b/tests/unit/test_http_security.py
@@ -207,32 +207,34 @@ async def test_valid_api_key_allows_real_fastmcp_tool_call() -> None:
     called: httpx.Response | None = None
     session_id: str | None = None
 
-    async with server.session_manager.run():
-        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as client:
-            initialized = await client.post("/mcp", json=initialize, headers=base_headers)
-            session_id = initialized.headers.get("mcp-session-id")
-            if initialized.status_code == 200 and session_id:
-                protocol_version = initialized.json()["result"]["protocolVersion"]
-                session_headers = {
-                    **base_headers,
-                    "Mcp-Session-Id": session_id,
-                    "Mcp-Protocol-Version": protocol_version,
-                }
-                notification = await client.post(
-                    "/mcp",
-                    json={"jsonrpc": "2.0", "method": "notifications/initialized"},
-                    headers=session_headers,
-                )
-                called = await client.post(
-                    "/mcp",
-                    json={
-                        "jsonrpc": "2.0",
-                        "id": 2,
-                        "method": "tools/call",
-                        "params": {"name": "ping", "arguments": {}},
-                    },
-                    headers=session_headers,
-                )
+    async with (
+        server.session_manager.run(),
+        httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:8000") as client,
+    ):
+        initialized = await client.post("/mcp", json=initialize, headers=base_headers)
+        session_id = initialized.headers.get("mcp-session-id")
+        if initialized.status_code == 200 and session_id:
+            protocol_version = initialized.json()["result"]["protocolVersion"]
+            session_headers = {
+                **base_headers,
+                "Mcp-Session-Id": session_id,
+                "Mcp-Protocol-Version": protocol_version,
+            }
+            notification = await client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+                headers=session_headers,
+            )
+            called = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": "ping", "arguments": {}},
+                },
+                headers=session_headers,
+            )
 
     assert initialized is not None
     assert initialized.status_code == 200, initialized.text

--- a/tests/unit/test_nmap_tool.py
+++ b/tests/unit/test_nmap_tool.py
@@ -9,43 +9,38 @@ def nmap():
 
 
 class TestNmapValidation:
-    def test_valid_params(self, nmap):
-        params = {"target": "10.10.10.1", "scan_type": "-sV", "ports": "80,443"}
-        validated = nmap.validate(params)
-        assert validated["target"] == "10.10.10.1"
-        assert validated["scan_type"] == "-sV"
-        assert validated["ports"] == "80,443"
+    def test_valid_target(self, nmap):
+        result = nmap.validate({"target": "10.10.10.1"})
+        assert result["target"] == "10.10.10.1"
+        assert result["scan_type"] == "-sV"
+
+    def test_hostname_target(self, nmap):
+        result = nmap.validate({"target": "box.htb"})
+        assert result["target"] == "box.htb"
+
+    def test_cidr_target(self, nmap):
+        result = nmap.validate({"target": "10.10.10.0/24"})
+        assert result["target"] == "10.10.10.0/24"
 
     def test_missing_target_raises(self, nmap):
         with pytest.raises(ValueError, match="Target parameter is required"):
-            nmap.validate({"scan_type": "-sV"})
-
-    def test_empty_target_raises(self, nmap):
-        with pytest.raises(ValueError, match="Target parameter is required"):
-            nmap.validate({"target": "", "scan_type": "-sV"})
+            nmap.validate({})
 
     def test_invalid_scan_type_raises(self, nmap):
-        with pytest.raises(ValueError, match="Invalid scan_type"):
+        with pytest.raises(ValueError, match="Invalid scan type"):
             nmap.validate({"target": "10.10.10.1", "scan_type": "-sZ"})
+
+    def test_valid_ports(self, nmap):
+        result = nmap.validate({"target": "10.10.10.1", "ports": "80,443,8080"})
+        assert result["ports"] == "80,443,8080"
+
+    def test_port_range(self, nmap):
+        result = nmap.validate({"target": "10.10.10.1", "ports": "1-1024"})
+        assert result["ports"] == "1-1024"
 
     def test_invalid_ports_raises(self, nmap):
         with pytest.raises(ValueError, match="Invalid ports"):
             nmap.validate({"target": "10.10.10.1", "ports": "80;rm"})
-
-    def test_shell_metacharacters_in_additional_args_raises(self, nmap):
-        with pytest.raises(ValueError, match="Unsafe token"):
-            nmap.validate({
-                "target": "10.10.10.1",
-                "additional_args": "--script=`id`",
-            })
-
-    def test_default_scan_type_is_sV(self, nmap):
-        validated = nmap.validate({"target": "10.10.10.1"})
-        assert validated["scan_type"] == "-sV"
-
-    def test_default_ports_is_empty(self, nmap):
-        validated = nmap.validate({"target": "10.10.10.1"})
-        assert validated["ports"] == ""
 
     def test_invalid_target_characters_raises(self, nmap):
         with pytest.raises(ValueError, match="Invalid target"):
@@ -53,8 +48,7 @@ class TestNmapValidation:
 
     @pytest.mark.parametrize(
         "scan_type",
-        ["-sV", "-sS", "-sU", "-sT", "-sA", "-sN", "-sF", "-sX",
-         "-sC", "-sP", "-sn", "-O", "-A"],
+        ["-sV", "-sS", "-sU", "-sT", "-sA", "-sN", "-sF", "-sX", "-sC", "-sP", "-sn", "-O", "-A"],
     )
     def test_all_valid_scan_types(self, nmap, scan_type):
         validated = nmap.validate({"target": "10.10.10.1", "scan_type": scan_type})
@@ -75,10 +69,10 @@ class TestNmapBuildCommand:
     def test_command_with_additional_args(self, nmap):
         validated = nmap.validate({
             "target": "10.10.10.1",
-            "additional_args": "-v --script=http-enum",
+            "additional_args": "-v --reason",
         })
         cmd = nmap.build_command(validated)
-        assert cmd == ["nmap", "-sV", "-v", "--script=http-enum", "10.10.10.1"]
+        assert cmd == ["nmap", "-sV", "-v", "--reason", "10.10.10.1"]
 
     def test_target_is_last_in_command(self, nmap):
         validated = nmap.validate({
@@ -93,5 +87,4 @@ class TestNmapBuildCommand:
     def test_scan_type_is_second_element(self, nmap):
         validated = nmap.validate({"target": "10.10.10.1", "scan_type": "-sS"})
         cmd = nmap.build_command(validated)
-        assert cmd[0] == "nmap"
         assert cmd[1] == "-sS"

--- a/tests/unit/test_nmap_tool.py
+++ b/tests/unit/test_nmap_tool.py
@@ -9,38 +9,43 @@ def nmap():
 
 
 class TestNmapValidation:
-    def test_valid_target(self, nmap):
-        result = nmap.validate({"target": "10.10.10.1"})
-        assert result["target"] == "10.10.10.1"
-        assert result["scan_type"] == "-sV"
-
-    def test_hostname_target(self, nmap):
-        result = nmap.validate({"target": "box.htb"})
-        assert result["target"] == "box.htb"
-
-    def test_cidr_target(self, nmap):
-        result = nmap.validate({"target": "10.10.10.0/24"})
-        assert result["target"] == "10.10.10.0/24"
+    def test_valid_params(self, nmap):
+        params = {"target": "10.10.10.1", "scan_type": "-sV", "ports": "80,443"}
+        validated = nmap.validate(params)
+        assert validated["target"] == "10.10.10.1"
+        assert validated["scan_type"] == "-sV"
+        assert validated["ports"] == "80,443"
 
     def test_missing_target_raises(self, nmap):
         with pytest.raises(ValueError, match="Target parameter is required"):
-            nmap.validate({})
+            nmap.validate({"scan_type": "-sV"})
+
+    def test_empty_target_raises(self, nmap):
+        with pytest.raises(ValueError, match="Target parameter is required"):
+            nmap.validate({"target": "", "scan_type": "-sV"})
 
     def test_invalid_scan_type_raises(self, nmap):
-        with pytest.raises(ValueError, match="Invalid scan type"):
+        with pytest.raises(ValueError, match="Invalid scan_type"):
             nmap.validate({"target": "10.10.10.1", "scan_type": "-sZ"})
-
-    def test_valid_ports(self, nmap):
-        result = nmap.validate({"target": "10.10.10.1", "ports": "80,443,8080"})
-        assert result["ports"] == "80,443,8080"
-
-    def test_port_range(self, nmap):
-        result = nmap.validate({"target": "10.10.10.1", "ports": "1-1024"})
-        assert result["ports"] == "1-1024"
 
     def test_invalid_ports_raises(self, nmap):
         with pytest.raises(ValueError, match="Invalid ports"):
             nmap.validate({"target": "10.10.10.1", "ports": "80;rm"})
+
+    def test_shell_metacharacters_in_additional_args_raises(self, nmap):
+        with pytest.raises(ValueError, match="Unsafe token"):
+            nmap.validate({
+                "target": "10.10.10.1",
+                "additional_args": "--script=`id`",
+            })
+
+    def test_default_scan_type_is_sV(self, nmap):
+        validated = nmap.validate({"target": "10.10.10.1"})
+        assert validated["scan_type"] == "-sV"
+
+    def test_default_ports_is_empty(self, nmap):
+        validated = nmap.validate({"target": "10.10.10.1"})
+        assert validated["ports"] == ""
 
     def test_invalid_target_characters_raises(self, nmap):
         with pytest.raises(ValueError, match="Invalid target"):
@@ -48,7 +53,8 @@ class TestNmapValidation:
 
     @pytest.mark.parametrize(
         "scan_type",
-        ["-sV", "-sS", "-sU", "-sT", "-sA", "-sN", "-sF", "-sX", "-sC", "-sP", "-sn", "-O", "-A"],
+        ["-sV", "-sS", "-sU", "-sT", "-sA", "-sN", "-sF", "-sX",
+         "-sC", "-sP", "-sn", "-O", "-A"],
     )
     def test_all_valid_scan_types(self, nmap, scan_type):
         validated = nmap.validate({"target": "10.10.10.1", "scan_type": scan_type})
@@ -87,4 +93,5 @@ class TestNmapBuildCommand:
     def test_scan_type_is_second_element(self, nmap):
         validated = nmap.validate({"target": "10.10.10.1", "scan_type": "-sS"})
         cmd = nmap.build_command(validated)
+        assert cmd[0] == "nmap"
         assert cmd[1] == "-sS"

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -74,12 +74,13 @@ class TestScopeEnforcerPermissive:
         enforcer = ScopeEnforcer(config_path=str(config_file))
         enforcer.validate_target("anything.com")
 
-    def test_empty_allowed_lists_permissive(self, tmp_path):
+    def test_explicit_empty_allowed_lists_deny_everything(self, tmp_path):
         config = {"scope": {"allowed_cidrs": [], "allowed_domains": []}}
         config_file = tmp_path / "empty_lists.yaml"
         config_file.write_text(yaml.dump(config))
         enforcer = ScopeEnforcer(config_path=str(config_file))
-        enforcer.validate_target("anything.com")
+        with pytest.raises(ScopeViolationError, match="not in scope"):
+            enforcer.validate_target("anything.com")
 
 
 class TestToolRestrictions:

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -84,8 +84,12 @@ class TestValidateAdditionalArgs:
         assert validate_additional_args("-v") == ["-v"]
 
     def test_multiple_safe_tokens(self):
-        result = validate_additional_args("-v --script=http-enum")
-        assert result == ["-v", "--script=http-enum"]
+        result = validate_additional_args("-v --reason")
+        assert result == ["-v", "--reason"]
+
+    def test_rejects_nmap_script_flag(self):
+        with pytest.raises(ValueError, match="Blocked flag"):
+            validate_additional_args("--script=http-enum")
 
     def test_raises_on_semicolon(self):
         with pytest.raises(ValueError, match="Unsafe token"):


### PR DESCRIPTION
## Summary

Project Astro creates an `AuthManager`, but the streamable-HTTP request path does not use it. This draft adds one authentication boundary around the FastMCP ASGI app so tools, resources, prompts, engagement operations, and batch operations cannot be reached before authentication.

It also makes remote HTTP startup fail closed and hardens the Docker/Compose defaults.

## Changes

- authenticate every MCP HTTP request using `X-API-Key` or an OIDC bearer token
- return `401` for missing, invalid, malformed, or rate-limited credentials
- keep `/health` public and minimal
- refuse unauthenticated HTTP startup on non-loopback bind addresses
- preserve unauthenticated stdio and loopback-only local development
- require an MCP SDK version that supports streamable HTTP
- require `API_KEY` in Compose and publish only on host loopback
- validate the container's internal bind explicitly
- add API-key boundary tests and a real FastMCP initialize/tool-call integration test
- add Python, package, Compose, Kali image, runtime-binary, and live-container CI

## Exact-head evidence

Fork head: `2ebe9624e44a85b0c7b3fdad32b6c42d60954c89`

Fork workflow run: `30312569964`

- Python 3.10: green
- Python 3.12: green
- pytest: 323 passed
- focused Ruff: green
- focused mypy: green
- package build: green
- Compose validation: green
- Kali image build: green
- registered runtime binary inventory: green
- live container health: green
- unauthenticated MCP HTTP initialize request: rejected with `401`

The repository-wide Ruff and mypy scans still expose pre-existing baseline debt and are reported as warnings in this focused PR; they were not mass-reformatted or weakened.

## Deliberately separate follow-ups

This draft does not repair the independently confirmed batch-dispatch scope bypass, process-tree timeout handling, arbitrary-script isolation, global engagement context, unused tool restrictions, artifact provenance, or persistent-session model. Each should be a separate reviewable change.